### PR TITLE
Overhaul main Swal class, replacing repeated session()->flash() with …

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,7 +1,17 @@
-@if (session()->has('sweetalert2'))
-  <script type="module">
-    import Swal from 'https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.esm.all.min.js';
+<script type="module">
+    let Swal;
+    if (window.Swal) {
+        Swal = window.Swal;
+    } else {
+        const sweetalert2Module = await import('https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.esm.all.min.js');
+        Swal = sweetalert2Module.default;
+    }
+    @session('sweetalert2')
+    Swal.fire(@json($value));
+    @endsession
+    window.addEventListener('sweetalert2', (event) => {
+        console.log(event);
+        Swal.fire(event.detail);
+    });
+</script>
 
-    Swal.fire(@json(session('sweetalert2')));
-  </script>
-@endif

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,8 +2,16 @@
 
 namespace SweetAlert2\Laravel;
 
+/**
+ * Laravel SweetAlert2 Integration Service Provider {@see https://github.com/sweetalert2/sweetalert2-laravel}
+ * @package SweetAlert2\Laravel
+ * @see https://sweetalert2.github.io
+ */
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
+    /*
+     * Bootstrap the package services
+     */
     public function boot(): void
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'sweetalert2');

--- a/src/Traits/WithSweetAlert.php
+++ b/src/Traits/WithSweetAlert.php
@@ -1,52 +1,59 @@
 <?php declare(strict_types=1);
 
-namespace SweetAlert2\Laravel;
+namespace SweetAlert2\Laravel\Traits;
 
-use SweetAlert2\Laravel\Traits\WithSweetAlert;
+use SweetAlert2\Laravel\Swal;
 
 /**
- * Laravel SweetAlert2 Integration {@see https://github.com/sweetalert2/sweetalert2-laravel}
+ * Laravel & Livewire SweetAlert2 Integration {@see https://github.com/sweetalert2/sweetalert2-laravel}
  *
- * Livewire components can use the trait {@see WithSweetAlert} to dispatch SweetAlert2 events within the component lifecycle.
+ * This trait should be used in a Livewire context to dispatch SweetAlert2 events within the component lifecycle.
+ *
+ * Non Livewire contexts should use the regular Laravel integration {@see Swal}. If this trait is used outside a
+ * Livewire context it will flash the SweetAlert2 event to the session like normal.
  *
  * Example usage:
  * <code>
- *     Swal::fire(['title' => 'Hello World!', 'icon' => 'success']);
+ *     $this->swalFire(['title' => 'Hello World!', 'icon' => 'success']);
  * </code>
  *
  * @package SweetAlert2\Laravel
  * @see https://sweetalert2.github.io
  */
-class Swal
+trait WithSweetAlert
 {
     /**
      * Displays a SweetAlert2 popup.
      *
      * Example usage:
      * <code>
-     *     Swal::fire(['title' => 'Hello World!', 'icon' => 'success']);
+     *     $this->swalFire(['title' => 'Hello World!', 'icon' => 'success']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the popup {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function fire(array $options = []): void
+    public function swalFire(array $options = []): void
     {
-        session()->flash('sweetalert2', $options);
+        if (method_exists($this, 'dispatch')) {
+            $this->dispatch('sweetalert2', ...$options);
+        } else {
+            session()->flash('sweetalert2', $options);
+        }
     }
 
     /**
      * Displays a SweetAlert2 popup with a success icon.
      *
      * Example usage:
-     * <code>
-     *     Swal::success(['title' => 'Hello World!']);
-     * </code>
+     *  <code>
+     *      $this->swalSuccess(['title' => 'Hello World!']);
+     *  </code>
      *
      * @param array $options Optional configuration parameters to customize the popup {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function success(array $options = []): void
+    public function swalSuccess(array $options = []): void
     {
-        self::fire(['icon' => 'success', ...$options]);
+        $this->swalFire(['icon' => 'success', ...$options]);
     }
 
     /**
@@ -54,14 +61,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::error(['title' => 'Hello World!']);
+     *     $this->swalError(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the popup {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function error(array $options = []): void
+    public function swalError(array $options = []): void
     {
-        self::fire(['icon' => 'error', ...$options]);
+        $this->swalFire(['icon' => 'error', ...$options]);
     }
 
     /**
@@ -69,14 +76,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::warning(['title' => 'Hello World!']);
+     *     $this->swalWarning(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the popup {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function warning(array $options = []): void
+    public function swalWarning(array $options = []): void
     {
-        self::fire(['icon' => 'warning', ...$options]);
+        $this->swalFire(['icon' => 'warning', ...$options]);
     }
 
     /**
@@ -84,14 +91,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::info(['title' => 'Hello World!']);
+     *     $this->swalInfo(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the popup {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function info(array $options = []): void
+    public function swalInfo(array $options = []): void
     {
-        self::fire(['icon' => 'info', ...$options]);
+        $this->swalFire(['icon' => 'info', ...$options]);
     }
 
     /**
@@ -99,14 +106,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::question(['title' => 'Hello World!']);
+     *     $this->swalQuestion(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the popup {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function question(array $options = []): void
+    public function swalQuestion(array $options = []): void
     {
-        self::fire(['icon' => 'question', ...$options]);
+        $this->swalFire(['icon' => 'question', ...$options]);
     }
 
     /* Toast Functions */
@@ -116,14 +123,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::toast(['title' => 'Hello World!', 'icon' => 'success']);
+     *     $this->swalToast(['title' => 'Hello World!', 'icon' => 'success']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the toast {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function toast(array $options = []): void
+    public function swalToast(array $options = []): void
     {
-        self::fire(['toast' => true, ...$options]);
+        $this->swalFire(['toast' => true, ...$options]);
     }
 
     /**
@@ -131,14 +138,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::toastSuccess(['title' => 'Hello World!']);
+     *     $this->swalToastSuccess(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the toast {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function toastSuccess(array $options = []): void
+    public function swalToastSuccess(array $options = []): void
     {
-        self::fire(['toast' => true, 'icon' => 'success', ...$options]);
+        $this->swalFire(['toast' => true, 'icon' => 'success', ...$options]);
     }
 
     /**
@@ -146,14 +153,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::toastError(['title' => 'Hello World!']);
+     *     $this->swalToastError(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the toast {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function toastError(array $options = []): void
+    public function swalToastError(array $options = []): void
     {
-        self::fire(['toast' => true, 'icon' => 'error', ...$options]);
+        $this->swalFire(['toast' => true, 'icon' => 'error', ...$options]);
     }
 
     /**
@@ -161,14 +168,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::toastWarning(['title' => 'Hello World!']);
+     *     $this->swalToastWarning(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the toast {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function toastWarning(array $options = []): void
+    public function swalToastWarning(array $options = []): void
     {
-        self::fire(['toast' => true, 'icon' => 'warning', ...$options]);
+        $this->swalFire(['toast' => true, 'icon' => 'warning', ...$options]);
     }
 
     /**
@@ -176,14 +183,14 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::toastInfo(['title' => 'Hello World!']);
+     *     $this->swalToastInfo(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the toast {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function toastInfo(array $options = []): void
+    public function swalToastInfo(array $options = []): void
     {
-        self::fire(['toast' => true, 'icon' => 'info', ...$options]);
+        $this->swalFire(['toast' => true, 'icon' => 'info', ...$options]);
     }
 
     /**
@@ -191,13 +198,13 @@ class Swal
      *
      * Example usage:
      * <code>
-     *     Swal::toastQuestion(['title' => 'Hello World!']);
+     *     $this->swalToastQuestion(['title' => 'Hello World!']);
      * </code>
      *
      * @param array $options Optional configuration parameters to customize the toast {@see https://sweetalert2.github.io/#configuration}.
      */
-    public static function toastQuestion(array $options = []): void
+    public function swalToastQuestion(array $options = []): void
     {
-        self::fire(['toast' => true, 'icon' => 'question', ...$options]);
+        $this->swalFire(['toast' => true, 'icon' => 'question', ...$options]);
     }
 }

--- a/tests/SwalTest.php
+++ b/tests/SwalTest.php
@@ -14,7 +14,7 @@ test('Swal::fire()', function () {
 
     $response
         ->assertStatus(200)
-        ->assertSee("import Swal from 'https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.esm.all.min.js'", escape: false)
+        ->assertSee("const sweetalert2Module = await import('https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.esm.all.min.js')", escape: false)
         ->assertSee('Swal.fire({"title":"SweetAlert2 + Laravel = \u003C3","text":"This is a simple alert using SweetAlert2","icon":"success","confirmButtonText":"Cool"})', escape: false);
 });
 


### PR DESCRIPTION
# Integration overhaul, Livewire & Local module support

## Integration Overhaul

Overhaul main Swal class, replacing repeated `session()->flash()` with `self::fire()`.

Add PHPDocs for the class and every function with simple descriptions of the functions, links to relevant documentation and example usage code blocks.

Add PHPDocs to ServiceProvider with links to documentation.

## Livewire Support

Add new WithSweetAlert trait for displaying popups and toasts in Livewire component lifecycles. Follow same convention for function usage and naming as main Swal class. Trait has a fallback when used outside Livewire context so can be used in regular Laravel controllers, middleware etc and installed on projects without Livewire.

Link back to WithSweetAlert trait in Swal class PHPDocs and vice versa.

Update index blade view to use @session rather than session has and add new `sweetalert2` window event listener for Livewire support.

## Locally Installed Swal Module Support

Add ability for integration to use locally installed Swal from app.js, to enable this users should import the Swal module and set `window.Swal` to the imported module for example:

```
import Swal from "sweetalert2";
window.Swal = Swal;
```

If `window.Swal` isn't set then the module is fetched externally from [jsDelivr](https://www.jsdelivr.com) like before.

Update SwalTest to accommodate for new import format.

## Resolves Issue(s)

- [x] #1 

## TODO

- [ ] Update tests with appropriate tests for the new WithSweetAlert trait 
- [ ] Update readme to document new WithSweetAlert trait and ability to use locally installed Swal module.