### PR TITLE
chore: upgrade Pest to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "require-dev": {
     "laravel/pint": "^1.20",
-    "pestphp/pest": "^4.0"
+    "pestphp/pest": "^5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Bumps the `pestphp/pest` dev requirement from `^4.0` to `^5.0`.

`composer update pestphp/pest --with-all-dependencies` resolves to **v5.0.3**, which brings PHPUnit 12.5 → 13.2 along with the `arch`, `mutate`, and `profanity` plugins at `^5.0`. `composer.lock` is gitignored, so the diff is a single line.

No test code changes were needed — nothing in the suite hits a Pest 4 → 5 breaking change.

## Verification

The suite can't run standalone in this repo (no `phpunit.xml`/`Pest.php` — there's no app to boot), so I replicated `.github/workflows/test.yml` exactly against a fresh Laravel app: `laravel new --pest` → local path repo → `composer require sweetalert2/laravel:@dev` → copy tests and views → `./vendor/bin/pest`.

```
Pest Testing Framework 5.0.3
tests: 25, passed: 25, assertions: 63, duration: 206ms
```

The CI workflow itself needed no edit: the Laravel installer already provisions Pest 5 in fresh apps, which is what CI actually runs against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)